### PR TITLE
Bug fix of argument -prefix in command line

### DIFF
--- a/master/src/main/java/org/evosuite/executionmode/TestGeneration.java
+++ b/master/src/main/java/org/evosuite/executionmode/TestGeneration.java
@@ -191,7 +191,7 @@ public class TestGeneration {
 				continue;
 			}
 			LoggingUtils.getEvoLogger().info("* Current class: "+ sut);
-			results.addAll(generateTests(Strategy.EVOSUITE,sut,args));
+			results.addAll(generateTests(Strategy.MOSUITE,sut,args));
 		}
 		return results;
 	}


### PR DESCRIPTION
Fixed the error when using the argument "-prefix" in the command line. 
For example, the command "$EVOSUITE -prefix tutorial" is supposed to test all classes in the tutorial package. 
However, the generation of tests fails because the default algorithm (DynaMOSA) uses test cases as individuals, but Evosuite is using test suites as individuals. 
There's also a warning about not using "Rank_Crowd_Distance_Tournament" selection function which was originally implemented with MOSA.